### PR TITLE
Implement GraphQL endpoint

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -20,10 +20,18 @@ juniper::graphql_object!(Mutation: Repository | &self | {});
 /// The GraphQL schema can be queries by users.
 pub type Schema = juniper::RootNode<'static, Query, Mutation>;
 
+/// Create a schema.
+///
+/// This method initializes the schema with the default query and mutation
+/// objects.
+pub fn create_schema() -> Schema {
+    Schema::new(Query, Mutation)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::{Config, Environment};
-    use crate::graphql::{Mutation, Query, Schema};
+    use crate::graphql::create_schema;
     use crate::router::Repository;
     use juniper::Variables;
 
@@ -41,7 +49,7 @@ mod tests {
         let (result, _errors) = juniper::execute(
             "query { apiVersion }",
             None,
-            &Schema::new(Query, Mutation),
+            &create_schema(),
             &Variables::new(),
             &repo(),
         )

--- a/src/handlers/graphql.rs
+++ b/src/handlers/graphql.rs
@@ -1,24 +1,77 @@
 //! The `graphql` module implements the endpoint for GraphQL queries.
 
+use crate::router::{AppState, Repository};
 use futures::future;
-use gotham::handler::HandlerFuture;
+use futures::future::Future;
+use futures::stream::Stream;
+use gotham::handler::{HandlerFuture, IntoHandlerError};
 use gotham::helpers::http::response::create_response;
-use gotham::state::State;
-use hyper::StatusCode;
+use gotham::router::response::extender::StaticResponseExtender;
+use gotham::state::{FromState, State, StateData};
+use hyper::{Body, Response, StatusCode};
+use juniper::http::GraphQLRequest;
+use juniper::{DefaultScalarValue, InputValue, ScalarValue};
+use serde::{Deserialize, Serialize};
 
-/// The GraphQL endpoint has a single handler that accepts a GraphQL query,
-/// executes it, and returns the results.
-pub fn execute(state: State) -> Box<HandlerFuture> {
-    let response = create_response(
-        &state,
-        StatusCode::OK,
-        mime::APPLICATION_JSON,
-        String::from("GraphQL endpoint"),
-    );
+/// The GraphQL extractor is used to parse an incoming GraphQL request, and
+/// extract its different parts into the following struct.
+#[derive(Serialize, Deserialize)]
+pub struct GraphQLRequestExtractor<S = DefaultScalarValue>
+where
+    S: ScalarValue + Sync + Send,
+{
+    query: String,
+    #[serde(rename = "operationName")]
+    operation_name: Option<String>,
+    #[serde(bound(deserialize = "InputValue<S>: Deserialize<'de> + Serialize"))]
+    variables: Option<InputValue<S>>,
+}
 
-    let future = future::ok((state, response));
+impl StateData for GraphQLRequestExtractor {}
+impl StaticResponseExtender for GraphQLRequestExtractor {
+    type ResBody = Body;
+    fn extend(_state: &mut State, _res: &mut Response<Body>) {}
+}
+
+/// Respond to a GraphQL query via POST.
+pub fn post(mut state: State) -> Box<HandlerFuture> {
+    let future = Body::take_from(&mut state)
+        .concat2()
+        .then(|body| match body {
+            Ok(body) => match String::from_utf8(body.to_vec()) {
+                Ok(json) => match serde_json::from_str(json.as_str()) {
+                    Ok(request) => future::ok(execute(state, request)),
+                    Err(e) => future::err((state, e.into_handler_error())),
+                },
+                Err(e) => future::err((state, e.into_handler_error())),
+            },
+            Err(e) => future::err((state, e.into_handler_error())),
+        });
 
     Box::new(future)
+}
+
+fn execute(state: State, graphql: GraphQLRequest) -> (State, Response<Body>) {
+    let graphql_schema = AppState::borrow_from(&state).schema.clone();
+    let repository = Repository::borrow_from(&state).clone();
+
+    let result = graphql.execute(&graphql_schema, &repository);
+
+    let status_code = if result.is_ok() {
+        StatusCode::OK
+    } else {
+        StatusCode::BAD_REQUEST
+    };
+    let response_as_json = serde_json::to_string_pretty(&result).unwrap_or_else(|_| String::new());
+
+    let response = create_response(
+        &state,
+        status_code,
+        mime::APPLICATION_JSON,
+        response_as_json,
+    );
+
+    (state, response)
 }
 
 #[cfg(test)]
@@ -47,19 +100,33 @@ mod tests {
     }
 
     #[test]
-    fn check_status_ok() {
-        let response = post_execute(String::from("graphql"), String::new());
+    fn execute_status_ok() {
+        let response = post_execute(
+            String::from("graphql"),
+            String::from("{\"query\":\"{ apiVersion }\"}"),
+        );
         assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[test]
-    fn check_body() {
-        let response = post_execute(String::from("graphql"), String::new());
+    #[ignore]
+    fn execute_status_bad_request() {
+        let response = post_execute(String::from("graphql"), String::from("{}"));
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn execute_body_ok() {
+        let response = post_execute(
+            String::from("graphql"),
+            String::from("{\"query\":\"{ apiVersion }\"}"),
+        );
 
         let body = response.read_body().unwrap();
         let body_as_str = str::from_utf8(&body).unwrap();
 
-        let expected = String::from("GraphQL endpoint");
+        let expected =
+            serde_json::to_string_pretty(&json!({ "data": { "apiVersion": "1.0" }})).unwrap();
 
         assert_eq!(body_as_str, expected);
     }

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -35,7 +35,7 @@ pub fn check(state: State) -> Box<HandlerFuture> {
 
     let future = repo
         .run(move |connection| sql_query("SELECT 1").execute(&connection))
-        .map_err(|e| e.into_handler_error())
+        .map_err(IntoHandlerError::into_handler_error)
         .then(move |result| {
             let postgres_status = match result {
                 Ok(_) => Status::Pass,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,10 @@
 extern crate diesel;
 #[macro_use]
 extern crate gotham_derive;
-#[macro_use]
+#[cfg_attr(test, macro_use)]
 extern crate juniper;
+#[cfg_attr(test, macro_use)]
+extern crate serde_json;
 
 pub mod config;
 pub mod graphql;


### PR DESCRIPTION
The previously empty endpoint for GraphQL has been implemented. The
implementation has been largely inspired by Juniper's existing
integrations with other web frameworks.

At this point, no useful error message is returned when an invalid
request is sent to the server. And GET requests are not support yet as
well.