### PR TITLE
Add name and description to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,10 @@
 ---
-labels: "type : bug"
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'type : bug'
+assignees: ''
+
 ---
 
 ### Describe the bug


### PR DESCRIPTION
GitHub requires templates to have a name and a description, otherwise
the template won't be used.